### PR TITLE
1025 park - 오류수정

### DIFF
--- a/src/main/java/com/project/erpre/model/dto/OrderDTO.java
+++ b/src/main/java/com/project/erpre/model/dto/OrderDTO.java
@@ -27,6 +27,7 @@ public class OrderDTO {
     private String orderHDeleteYn; // 삭제 여부 기본값 'N'
     private Timestamp orderHDeleteDate; // 삭제 일시
     // 추가된 필드
+    @Builder.Default
     private List<OrderDetailDTO> orderDetails = new ArrayList<>();
     private List<Integer> deletedDetailIds; // 삭제할 상세항목 id 배열
     private List<Product> products; // 상품 리스트

--- a/src/main/java/com/project/erpre/model/dto/OrderDetailDTO.java
+++ b/src/main/java/com/project/erpre/model/dto/OrderDetailDTO.java
@@ -22,6 +22,7 @@ public class OrderDetailDTO {
 
     private LocalDateTime orderDInsertDate;
     private LocalDateTime orderDUpdateDate;
+    @Builder.Default
     private String orderDDeleteYn = "N"; // 기본값 설정
     private Timestamp orderDDeleteDate; // 삭제 일시
 

--- a/src/main/java/com/project/erpre/model/entity/OrderDetail.java
+++ b/src/main/java/com/project/erpre/model/entity/OrderDetail.java
@@ -52,6 +52,7 @@ public class OrderDetail {
     @Column(name = "order_d_update_date")
     private LocalDateTime orderDUpdateDate;
 
+    @Builder.Default
     @Column(name = "order_d_delete_yn", nullable = false)
     private String orderDDeleteYn="N";
 

--- a/src/main/java/com/project/erpre/repository/ChatRepositoryImpl.java
+++ b/src/main/java/com/project/erpre/repository/ChatRepositoryImpl.java
@@ -32,7 +32,7 @@ public class ChatRepositoryImpl implements ChatRepositoryCustom {
         return queryFactory
                 .select(Projections.constructor(ChatDTO.class,
                         chat.chatNo,
-                        chatParticipant.chat.chatTitle,
+                        chatParticipant.chatTitle,
                         chatParticipant.chatParticipantId.participantId,
                         chatParticipant.employee.employeeName,
                         chatMessage.chatMessageContent,
@@ -47,7 +47,7 @@ public class ChatRepositoryImpl implements ChatRepositoryCustom {
                         .and(searchKeywordIsNullOrEmpty(searchKeyword)))
                 .groupBy(
                         chat.chatNo,
-                        chatParticipant.chat.chatTitle,
+                        chatParticipant.chatTitle,
                         chatParticipant.chatParticipantId.participantId,
                         chatParticipant.employee.employeeName,
                         chatMessage.chatMessageContent,
@@ -64,7 +64,7 @@ public class ChatRepositoryImpl implements ChatRepositoryCustom {
         }
         QChatParticipant chatParticipant = QChatParticipant.chatParticipant;
 
-        return chatParticipant.chat.chatTitle.containsIgnoreCase(keyword)
+        return chatParticipant.chatTitle.containsIgnoreCase(keyword)
                 .or(chatParticipant.employee.employeeName.containsIgnoreCase(keyword));
     }
 


### PR DESCRIPTION
@Builder.Default

기본값 설정 보장 -> @Builder는 필드의 초기화 값 무시한다.  예를 들어 private String orderDDeleteYn = "N";으로 초기화했더라도, @Builder로 생성하는 경우 "N"이 기본값으로 설정되지 않는다. 만약 @Builder.Default를 추가하지 않으면 해당 필드가 기본값 없이 null이 되거나, 빈 리스트가 아닌 null 리스트로 생성될 수 있다.

:: @Builder 패턴을 사용할 때, 기본값이 필요한 필드에는 @Builder.Default를 추가해주는 것이 좋다